### PR TITLE
properly join paths, otherwise fails with EACCES

### DIFF
--- a/lib/mustache.js
+++ b/lib/mustache.js
@@ -22,9 +22,10 @@ define(function() {
 		if(config.isBuild) {
 			var fs = require.nodeRequire('fs'),
 				shell = require.nodeRequire('shelljs'),
+				node_path = require.nodeRequire('path'),
 				tempdir = shell.tempdir(),
 				cleanPath = toId(name),
-				filename = tempdir + cleanPath,
+				filename = node_path.join(tempdir, cleanPath),
 				built;
 
 			shell.exec('node_modules/can-compile/bin/can-compile ' + path + ' --out ' + filename);


### PR DESCRIPTION
the problem occurs when using requirejs in conjuction with mustache canjs-renderer as soon as templates are to be included in a build. the temporary file is missing a `/` in its path trying to write to the root directory at `/tmptemplatename` where it should read `/tmp/templatename`
